### PR TITLE
Updated to Firestore v7.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "realtime"
     ],
     "dependencies": {
-        "firebase": "^6.x.x"
+        "firebase": "^7.x.x"
     },
     "devDependencies": {
         "@types/chai": "^4.1.4",


### PR DESCRIPTION
Fix install grpc failed on node 13

https://github.com/grpc/grpc-node/issues/1216

build grpc issue already fixed in 1.24.2

and `firestore^6` force install grpc 1.23.3

firestore upgraded grpc 1.24.2 in 7.3.0